### PR TITLE
Добавить guard для получения счетов, чтобы исключить утечку данных

### DIFF
--- a/src/main/java/ru/yandex/finance_tracker/service/AccountServiceImpl.java
+++ b/src/main/java/ru/yandex/finance_tracker/service/AccountServiceImpl.java
@@ -15,6 +15,7 @@ import ru.yandex.finance_tracker.mapper.AccountMapper;
 import ru.yandex.finance_tracker.mapper.TransactionMapper;
 import ru.yandex.finance_tracker.model.Account;
 import ru.yandex.finance_tracker.model.User;
+import ru.yandex.finance_tracker.security.utils.SecurityUtils;
 import ru.yandex.finance_tracker.storage.AccountRepository;
 import ru.yandex.finance_tracker.storage.TransactionRepository;
 import ru.yandex.finance_tracker.storage.UserRepository;
@@ -31,19 +32,26 @@ public class AccountServiceImpl implements AccountService {
     private final AccountMapper mapper;
     private final TransactionRepository transactionRepository;
     private final TransactionMapper transactionMapper;
+    private final SecurityUtils securityUtils;
 
     @Transactional(readOnly = true)
     @Override
     public List<AccountInfoDto> getAccountsByUserId(Long userId) {
         log.info("Запрос списка счетов для пользователя с ID: {}", userId);
-        if (userRepository.existsById(userId)) {
-            List<Account> accounts = accountRepository.findByUserId(userId);
-            log.info("Найдено счетов: {} для пользователя ID: {}", accounts.size(), userId);
-            return mapper.toDtoList(accounts);
-        } else {
+        Long currentUserId = securityUtils.getCurrentUserId();
+        if (!userId.equals(currentUserId)) {
+            log.error("Попытка доступа к чужим счетам: userId = {}", userId);
+            throw new AccessDeniedException("You can only access your own accounts");
+        }
+
+        if (!userRepository.existsById(userId)) {
             log.error("Ошибка получения счетов: пользователь с ID {} не существует", userId);
             throw new NotFoundException("User with ID %d not found".formatted(userId));
         }
+
+        List<Account> accounts = accountRepository.findByUserId(userId);
+        log.info("Найдено счетов: {} для пользователя ID: {}", accounts.size(), userId);
+        return mapper.toDtoList(accounts);
     }
 
     @Transactional

--- a/src/main/java/ru/yandex/finance_tracker/storage/AccountRepository.java
+++ b/src/main/java/ru/yandex/finance_tracker/storage/AccountRepository.java
@@ -19,7 +19,5 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     List<Account> findByUserId(Long userId);
 
-    Optional<Account> findByIdAndUserId(Long id, Long userId);
-
     boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/src/test/java/ru/yandex/finance_tracker/AccountServiceTests.java
+++ b/src/test/java/ru/yandex/finance_tracker/AccountServiceTests.java
@@ -11,8 +11,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import ru.yandex.finance_tracker.dto.input.AccountCreateRequest;
+import ru.yandex.finance_tracker.dto.output.AccountInfoDto;
 import ru.yandex.finance_tracker.dto.output.TransactionInfoDto;
 import ru.yandex.finance_tracker.exception.AccessDeniedException;
 import ru.yandex.finance_tracker.mapper.AccountMapper;
@@ -21,8 +21,6 @@ import ru.yandex.finance_tracker.model.*;
 import ru.yandex.finance_tracker.security.utils.SecurityUtils;
 import ru.yandex.finance_tracker.service.AccountService;
 import ru.yandex.finance_tracker.service.AccountServiceImpl;
-import ru.yandex.finance_tracker.service.TransactionService;
-import ru.yandex.finance_tracker.service.TransactionServiceImpl;
 import ru.yandex.finance_tracker.storage.AccountRepository;
 import ru.yandex.finance_tracker.storage.TransactionRepository;
 import ru.yandex.finance_tracker.storage.UserRepository;
@@ -32,6 +30,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -181,6 +180,47 @@ public class AccountServiceTests {
         verify(accountRepository)
                 .existsByIdAndUserId(accountId, userId);
 
+        verifyNoInteractions(transactionRepository);
+    }
+
+    @Test
+    void shouldReturnAccountsForCurrentUser() {
+        Long userId = 1L;
+        when(securityUtils.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.existsById(userId)).thenReturn(true);
+
+        List<Account> accounts = List.of(new Account(), new Account());
+        when(accountRepository.findByUserId(userId)).thenReturn(accounts);
+
+        List<AccountInfoDto> result = accountService.getAccountsByUserId(userId);
+
+        assertThat(result).hasSize(2);
+        verify(accountRepository).findByUserId(userId);
+    }
+
+    @Test
+    void shouldThrowAccessDeniedWhenRequestingAnotherUserAccounts() {
+        Long currentUserId = 1L;
+        Long requestedUserId = 2L;
+
+        when(securityUtils.getCurrentUserId()).thenReturn(currentUserId);
+
+        assertThrows(AccessDeniedException.class,
+                () -> accountService.getAccountsByUserId(requestedUserId));
+    }
+
+    @Test
+    void shouldThrowAccessDeniedWhenAccountDoesNotBelongToUser() {
+        Long userId = 1L;
+        Long accountId = 999L;
+
+        when(accountRepository.existsByIdAndUserId(accountId, userId))
+                .thenReturn(false);
+
+        assertThrows(AccessDeniedException.class,
+                () -> accountService.getTransactionsByAccountId(userId, accountId, 0, 20));
+
+        verify(accountRepository).existsByIdAndUserId(accountId, userId);
         verifyNoInteractions(transactionRepository);
     }
 }

--- a/src/test/java/ru/yandex/finance_tracker/AccountServiceTests.java
+++ b/src/test/java/ru/yandex/finance_tracker/AccountServiceTests.java
@@ -18,6 +18,7 @@ import ru.yandex.finance_tracker.exception.AccessDeniedException;
 import ru.yandex.finance_tracker.mapper.AccountMapper;
 import ru.yandex.finance_tracker.mapper.TransactionMapper;
 import ru.yandex.finance_tracker.model.*;
+import ru.yandex.finance_tracker.security.utils.SecurityUtils;
 import ru.yandex.finance_tracker.service.AccountService;
 import ru.yandex.finance_tracker.service.AccountServiceImpl;
 import ru.yandex.finance_tracker.service.TransactionService;
@@ -47,6 +48,8 @@ public class AccountServiceTests {
     private TransactionRepository transactionRepository;
     private TransactionMapper transactionMapper = Mappers.getMapper(TransactionMapper.class);
     private AccountService accountService;
+    @Mock
+    private SecurityUtils securityUtils;
 
     @BeforeEach
     void setUp() {
@@ -55,7 +58,8 @@ public class AccountServiceTests {
                 userRepository,
                 mapper,
                 transactionRepository,
-                transactionMapper
+                transactionMapper,
+                securityUtils
         );
     }
 


### PR DESCRIPTION
Исправлена уязвимость изоляции данных - в GET /api/v1/accounts добавлена проверка, что userId из запроса совпадает с id текущего аутентифицированного пользователя (из AuthInfo).
Попытка доступа к чужому счёту возвращает 403 Forbidden.