### PR TITLE
Исправить отображение отчётов за ещё не наступившие периоды

### DIFF
--- a/src/main/java/ru/yandex/finance_tracker/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ru/yandex/finance_tracker/exception/GlobalExceptionHandler.java
@@ -163,6 +163,21 @@ public class GlobalExceptionHandler {
         return buildResponse(HttpStatus.BAD_REQUEST, "Insufficient Funds", ex.getMessage());
     }
 
+    /**
+     * Обрабатывает исключение, возникающее при некорректной дате.
+     * <p>
+     * Исключение выбрасывается, когда дата в будущем.
+     * Возвращает статус 400 (Bad Request) с информацией об ошибке.
+     * </p>
+     *
+     * @param ex исключение, содержащее сообщение о несоответствии даты
+     * @return ResponseEntity с подробностями валидации и статусом 400 (Bad Request)
+     */
+    @ExceptionHandler(InvalidReportDateException.class)
+    public ResponseEntity<ApiError> handleInvalidReportDate(final InvalidReportDateException ex) {
+        return buildResponse(HttpStatus.BAD_REQUEST, "Validation Failed", ex.getMessage());
+    }
+
     private ResponseEntity<ApiError> buildResponse(HttpStatus status, String error, String message) {
         ApiError apiError = ApiError.builder()
                 .timestamp(LocalDateTime.now())

--- a/src/main/java/ru/yandex/finance_tracker/exception/InvalidReportDateException.java
+++ b/src/main/java/ru/yandex/finance_tracker/exception/InvalidReportDateException.java
@@ -1,0 +1,7 @@
+package ru.yandex.finance_tracker.exception;
+
+public class InvalidReportDateException extends RuntimeException {
+    public InvalidReportDateException(int year, int month) {
+        super("The requested date = %d.%d cannot be in the future".formatted(year, month));
+    }
+}

--- a/src/main/java/ru/yandex/finance_tracker/service/ReportServiceImpl.java
+++ b/src/main/java/ru/yandex/finance_tracker/service/ReportServiceImpl.java
@@ -5,12 +5,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ru.yandex.finance_tracker.dto.output.CategoryExpenseDto;
 import ru.yandex.finance_tracker.dto.output.MonthlyReportDto;
+import ru.yandex.finance_tracker.exception.InvalidReportDateException;
 import ru.yandex.finance_tracker.model.Type;
 import ru.yandex.finance_tracker.storage.TransactionRepository;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
@@ -22,6 +24,10 @@ public class ReportServiceImpl implements ReportService {
 
     public MonthlyReportDto getMonthlyReport(Long userId, int year, int month) {
         log.info("Начало формирования отчета для пользователя ID: {} за период: {}-{}", userId, year, month);
+
+        if (YearMonth.of(year, month).isAfter(YearMonth.now())) {
+            throw new InvalidReportDateException(year, month);
+        }
 
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.with(TemporalAdjusters.lastDayOfMonth());


### PR DESCRIPTION
Добавлена проверка на запрос отчёта даты в будущем.
Если год/месяц превышают текущую дату, контроллер возвращает ошибку 400 Bad Request с соответствующим сообщением.